### PR TITLE
Désactive l'envoi de mail au contact d'une suggestion…

### DIFF
--- a/dora/service_suggestions/models.py
+++ b/dora/service_suggestions/models.py
@@ -171,6 +171,8 @@ class ServiceSuggestion(models.Model):
                 #     emails_contacted.add(contact_email)
 
                 if emails_contacted:
+                    # FIXME: mettre des destinataires multiples dans le champ To: n'est sans doute pas une bonne idée…
+                    # voir: https://www.notion.so/dora-beta/Notification-de-suggestion-valid-e-destinataires-multiples-9d1aa1b15f334721a423346107aeab53
                     send_suggestion_validated_existing_structure_email(
                         list(emails_contacted), structure, service
                     )

--- a/dora/service_suggestions/models.py
+++ b/dora/service_suggestions/models.py
@@ -163,8 +163,12 @@ class ServiceSuggestion(models.Model):
                 for admin in structure_admins:
                     emails_contacted.add(admin.user.email)
 
-                if contact_email is not None:
-                    emails_contacted.add(contact_email)
+                # Pour l'instant on désactive l'envoi au contact_email, étant donnée que le message actuel
+                # n'est pas pertinent pour un utilisateur qui ne fait pas déjà partie de la structure,
+                # et on n'a pas cette garantie.
+
+                # if contact_email is not None:
+                #     emails_contacted.add(contact_email)
 
                 if emails_contacted:
                     send_suggestion_validated_existing_structure_email(

--- a/dora/service_suggestions/tests.py
+++ b/dora/service_suggestions/tests.py
@@ -2,12 +2,12 @@ from datetime import timedelta
 
 from django.core import mail
 from django.utils import timezone
-from dora.structures.models import StructureMember
 from model_bakery import baker
 from rest_framework.test import APITestCase, APITransactionTestCase
 
 from dora.core.test_utils import make_structure
 from dora.services.enums import ServiceStatus
+from dora.structures.models import StructureMember
 
 from .models import ServiceSuggestion
 
@@ -279,10 +279,10 @@ class ServiceSuggestionsTestCase(APITestCase):
         self.client.force_authenticate(user=bizdev_user)
         response = self.client.post(f"/services-suggestions/{suggestion.id}/validate/")
 
-        # ALORS l'administrateur et la personne en contact sont contactés
+        # ALORS seul l'administrateur est contacté
         self.assertEqual(
             sorted(response.data["emails_contacted"]),
-            sorted([admin_mail, contact_mail]),
+            sorted([admin_mail]),
         )
         self.assertIn(
             "[DORA] Vous avez reçu une nouvelle suggestion de service ! 🥳 🎉",


### PR DESCRIPTION
…quand la structure existe déjà

Corrige 
- https://www.notion.so/dora-beta/Ne-plus-envoyer-de-mail-de-notification-au-contact-d-une-contribution-dans-le-cas-d-une-structure-ex-3365704a6c5340e69968d230527bacc0
- https://www.notion.so/dora-beta/Corriger-le-mail-automatique-pour-les-structures-existantes-dans-le-cas-des-structures-orphelines-73a2ad39a4bd47fc8d1a850d069b5755
- https://www.notion.so/dora-beta/Notification-de-suggestion-valid-e-destinataires-multiples-9d1aa1b15f334721a423346107aeab53