### PR TITLE
Une recherche de besoins 'Autre' renvoie aussi les services sans besoin

### DIFF
--- a/dora/core/test_utils.py
+++ b/dora/core/test_utils.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.utils.crypto import get_random_string
 from model_bakery import baker
 
+from dora.services.models import ServiceCategory, ServiceSubCategory
 from dora.services.utils import update_sync_checksum
 
 
@@ -33,13 +34,25 @@ def make_structure(user=None, **kwargs):
 
 def make_service(**kwargs):
     structure = kwargs.pop("structure") if "structure" in kwargs else make_structure()
-    return baker.make(
+    categories = kwargs.pop("categories").split(",") if "categories" in kwargs else []
+    subcategories = (
+        kwargs.pop("subcategories").split(",") if "subcategories" in kwargs else []
+    )
+    service = baker.make(
         "Service",
         structure=structure,
         is_model=False,
         modification_date=timezone.now(),
         **kwargs,
     )
+    if categories:
+        service.categories.set(ServiceCategory.objects.filter(value__in=categories))
+    if subcategories:
+        service.subcategories.set(
+            ServiceSubCategory.objects.filter(value__in=subcategories)
+        )
+
+    return service
 
 
 def make_model(**kwargs):


### PR DESCRIPTION
https://trello.com/c/pqSgB6X0

@AlexandreCantin en conflit avec la tienne, mais tu peux déjà reviewer comme ça et on les fera évoluer dans l'ordre nécessaire. Celle-ci est urgente, donc à voir si on peut merger la partie back seulement des évolutions de la recherche dans un premier temps.