### PR TITLE
Warning au lieu d'un exception si le besoin n'existe pas

### DIFF
--- a/dora/services/migration_utils.py
+++ b/dora/services/migration_utils.py
@@ -1,5 +1,8 @@
-from django.conf import settings
+import logging
+
 from django.core.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
 
 
 def extract_subcategories(service):
@@ -132,12 +135,10 @@ def update_subcategory_value_and_label(
 ):
     old_subcategory = get_subcategory_by_value(ServiceSubCategory, old_value)
     if old_subcategory is None:
-        # Certains besoins ont été créés via une autre méthode qu'une migration (par le back-office)
-        # Du coup, certaines catégories peuvent ne pas exister et casser les migrations lors des tests…
-        if settings.IS_TESTING:
-            return
-
-        raise ValidationError(f"Aucun besoin trouvé avec la value: '{old_value}'")
+        logger.warning(
+            f"Modification du besoin '{old_value}' vers '{new_value}' va être ignorée car '{old_value}' n‘existe pas"
+        )
+        return
 
     new_subcategory = get_subcategory_by_value(ServiceSubCategory, new_value)
     if new_subcategory is not None:

--- a/dora/services/tests.py
+++ b/dora/services/tests.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.conf import settings
 from django.contrib.gis.geos import MultiPolygon, Point
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -42,14 +41,6 @@ from .models import (
 )
 
 DUMMY_SERVICE = {"name": "Mon service"}
-
-
-class disabled_is_testing_flag(object):
-    def __enter__(self):
-        settings.IS_TESTING = False
-
-    def __exit__(self, *args):
-        settings.IS_TESTING = True
 
 
 class ServiceTestCase(APITestCase):
@@ -2518,27 +2509,6 @@ class ServiceMigrationUtilsTestCase(APITestCase):
         self.assertTrue(subcategory is not None)
         self.assertEqual(subcategory.value, value)
         self.assertEqual(subcategory.label, label)
-
-    def test_update_subcategory_value_and_label_non_existing(self):
-        # Lors des tests, certaines catégories peuvent ne pas exister et casser les migrations…
-        # Du coup, les `ValidationError` dans `update_subcategory_value_and_label` sont désactivées
-        # Toutefois, il est nécessaire de les ré-activer dans le cadre de ce test
-        with disabled_is_testing_flag() as _:
-            # ÉTANT DONNÉ un besoin non existant
-            # QUAND je le modifie
-            try:
-                update_subcategory_value_and_label(
-                    ServiceSubCategory,
-                    old_value="value",
-                    new_value="whatever",
-                    new_label="new label",
-                )
-            except Exception as e:
-                err = e
-
-            # ALORS j'obtiens une erreur
-            self.assertTrue(isinstance(err, ValidationError))
-            self.assertTrue("Aucun besoin trouvé" in err.message)
 
     def test_update_subcategory_value_and_label_value_already_used(self):
         old_value = "old_value"


### PR DESCRIPTION
https://trello.com/c/Ah9ECu27/644-les-tests-du-backend-sont-cass%C3%A9s-par-les-derni%C3%A8res-migrations

