### PR TITLE
La date de mise à jour est prise en compte pour model_changed

### DIFF
--- a/dora/services/serializers.py
+++ b/dora/services/serializers.py
@@ -420,6 +420,8 @@ class ServiceSerializer(serializers.ModelSerializer):
 
     def get_model_changed(self, object):
         if object.model:
+            if object.model.modification_date < object.modification_date:
+                return False
             return object.model.sync_checksum != object.last_sync_checksum
         return None
 


### PR DESCRIPTION
https://trello.com/c/pvpBj1pD/798-modelchanged-doit-prendre-en-compte-les-dates-de-modification-du-service-et-du-mod%C3%A8le