### PR TITLE
Conservation de la thématique de recherche si on avons `--autre`

### DIFF
--- a/dora/services/views.py
+++ b/dora/services/views.py
@@ -811,6 +811,10 @@ def _get_di_results(
     if subcategories is not None:
         thematiques += [subcat for subcat in subcategories if "--autre" not in subcat]
 
+    # Cas spécifique si nous avons exclusivement un besoin `--autre`
+    if not thematiques and len(subcategories) == 1 and "--autre" in subcategories[0]:
+        thematiques = [subcategories[0].split("--")[0]]
+
     try:
         raw_di_results = di_client.search_services(
             sources=settings.DATA_INCLUSION_STREAM_SOURCES,


### PR DESCRIPTION
https://trello.com/c/PyngSKKq/881-filtres-besoins-autre

Si nous avons qu'un besoin `--autre`, les thématiques de recherche sont vides… donnant un grand nombre de résultat.
Du coup, dans ce cas de figure, on conserve la thématique de recherche :)